### PR TITLE
Added brightdata retriever and retriever use logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ RUN apt-get update \
     "chromium, chromium-driver (>= 115.0)" \
     && chromium --version && chromedriver --version
 
+    
+
 RUN apt-get update \
     && apt-get install -y --fix-missing firefox-esr wget \
     && wget https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux64.tar.gz \

--- a/gpt_researcher/config/config.py
+++ b/gpt_researcher/config/config.py
@@ -9,7 +9,8 @@ class Config:
     def __init__(self, config_file: str = None):
         """Initialize the config class."""
         self.config_file = os.path.expanduser(config_file) if config_file else os.getenv('CONFIG_FILE')
-        self.retriever = os.getenv('RETRIEVER', "tavily")
+        # self.retriever = os.getenv('RETRIEVER', "tavily")
+        self.retriever = os.getenv('RETRIEVER', "brightdata")
         self.embedding_provider = os.getenv('EMBEDDING_PROVIDER', 'openai')
         self.similarity_threshold = int(os.getenv('SIMILARITY_THRESHOLD', 0.38))
         self.llm_provider = os.getenv('LLM_PROVIDER', "openai")

--- a/gpt_researcher/master/actions.py
+++ b/gpt_researcher/master/actions.py
@@ -10,6 +10,7 @@ from gpt_researcher.scraper.scraper import Scraper
 from gpt_researcher.utils.llm import *
 
 
+
 def get_retriever(retriever):
     """
     Gets the retriever
@@ -52,6 +53,9 @@ def get_retriever(retriever):
             from gpt_researcher.retrievers import TavilySearch
 
             retriever = TavilySearch
+        case "brightdata":
+            from gpt_researcher.retrievers import BrightDataSearch
+            retriever = BrightDataSearch
         case "exa":
             from gpt_researcher.retrievers import ExaSearch
 

--- a/gpt_researcher/master/agent.py
+++ b/gpt_researcher/master/agent.py
@@ -1,5 +1,7 @@
 import asyncio
 import time
+import hashlib
+
 
 from gpt_researcher.config import Config
 from gpt_researcher.context.compression import ContextCompressor
@@ -9,7 +11,10 @@ from gpt_researcher.master.actions import *
 from gpt_researcher.memory import Memory
 from gpt_researcher.utils.enum import ReportSource, ReportType
 
+from gpt_researcher.master.logging import log_data_to_redshift
+
 import sys
+
 
 
 class GPTResearcher:
@@ -57,7 +62,7 @@ class GPTResearcher:
         self.report_source: str = report_source
         self.research_costs: float = 0.0
         self.cfg = Config(config_path)
-        self.retriever = get_retriever(self.cfg.retriever)
+        self.retriever = get_retriever(self.cfg.retriever) #we store the retiever class object. It is not instantiated here.
         self.context = context
         self.source_urls = source_urls
         self.web_search_queries = web_search_queries
@@ -255,7 +260,7 @@ class GPTResearcher:
         search_result = []
         if not scraped_data:
             scraped_data, search_result = await self.__scrape_data_by_query(sub_query)
-
+        
         search_result = [
             "Source: " + row.get("href") + "\n" + "Title: " + row.get("title") + "\n" + "Content: " + row.get("body") + "\n"
             for row in search_result
@@ -297,12 +302,35 @@ class GPTResearcher:
             Summary
         """
         # Get Urls
-        retriever = self.retriever(sub_query)
-        search_results = retriever.search(
+        retriever = self.retriever(sub_query) #we instantiate the retriever class here. We pass the query to the retriever class.
+        search_results, err_msg = retriever.search(
             max_results=self.cfg.max_search_results_per_query)
         
-        new_search_urls = await self.__get_new_urls([url.get("href") for url in search_results])
+        #log the search information
+        if len(err_msg) == 0:
+            log_data_to_redshift({
+                "vendor_name": self.cfg.retriever,
+                "api_name": "search",
+                "app_name": "gpt-researcher",
+                "event_count": 1,
+                "reference_id_type": "query_hash", 
+                "reference_id": hashlib.sha256(self.query.encode()).hexdigest(),
+                "status": "success",
+                "hit_cache": False,
+            })
+        else:
+            log_data_to_redshift({
+                "vendor_name": self.cfg.retriever,
+                "api_name": "search",
+                "app_name": "gpt-researcher",
+                "event_count": 1,
+                "reference_id_type": "query_hash", 
+                "reference_id": hashlib.sha256(self.query.encode()).hexdigest(),
+                "status": f"error - {err_msg}",
+                "hit_cache": False,
+            })
 
+        new_search_urls = await self.__get_new_urls([url.get("href") for url in search_results])
         # Scrape Urls
         if self.verbose:
             await stream_output("logs", f"🤔 Researching for relevant information...\n", self.websocket)

--- a/gpt_researcher/master/logging.py
+++ b/gpt_researcher/master/logging.py
@@ -1,0 +1,147 @@
+from botocore.client import Config
+import boto3
+import json
+from datetime import datetime, timezone
+import hashlib
+import logging
+import sys, os
+import inspect
+# Configure logger to output to console
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+logger.addHandler(handler)
+
+KINESIS_STREAM_NAME = "web-researcher-external-api-events-prod-DataStream"
+# Define fields for logging and Redshift table structure
+LOG_FIELDS = [
+    "id",
+    "vendor_name",
+    "api_name",
+    "reference_id_type",
+    "reference_id",
+    "app_name",
+    "app_context",
+    "status",
+    "hit_cache",
+    "event_count",
+    "event_time",
+]
+
+# def test():
+#     log_data_to_redshift({
+#        "vendor_name": "tavily",
+#        "api_name": "search",
+#        "reference_id_type": "lead_id",
+#        "reference_id": "999999",
+#        "app_name": "grazibot",
+#        "app_context": "grazibot_tavily_websearch",
+#        "status": "success",
+#        "hit_cache": False,
+#        "event_count": 1,
+#        "event_time": datetime.datetime.now(datetime.timezone.utc)
+#     })
+
+# log_data_to_redshift({
+#     "vendor_name": "brightdata",
+#     "api_name": "search",
+#     "app_context":"", #don't include. string added by get_call_stack_string()
+#     "app_name": self.app_name,
+#     "event_count": 1,
+#     "event_time": datetime.now().isoformat(), #don't include. timestamp added by log_data_to_redshift()
+#     "id": "123", #don't include. varchar added by log_data_to_redshift()
+#     "reference_id_type": self.reference_id_type,
+#     "reference_id": self.lead_id,
+#     "status": "success",
+#     "hit_cache": False,
+# })
+
+def get_call_stack_string(levels=4):
+    # Get the current call stack; index 0 is this function.
+    stack = inspect.stack()
+    call_stack = []
+    prev_filename = None
+
+    for frame_info in stack[2:levels+2]:
+        # Extract only the file name from the full file path.
+        current_file = os.path.basename(frame_info.filename)
+        if current_file != prev_filename:
+            # Include the file name if it's different from the previous one.
+            call_stack.append(f"{current_file}.{frame_info.function}")
+            prev_filename = current_file
+        else:
+            call_stack.append(frame_info.function)
+    
+    return "::".join(call_stack[::-1])
+
+
+def log_data_to_redshift(event_data):
+    """Log data to Kinesis and then to Redshift
+
+    Args:
+        event_data (dict): The data to log
+    """
+    # Create an id
+    created_at = str(datetime.now(timezone.utc))
+    hash_str = (str(event_data["reference_id"]) + "_" + created_at).encode()
+    hash_id = hashlib.md5(hash_str).hexdigest()
+    event_data["id"] = hash_id
+
+    # Convert datetime to string to make it JSON serializable
+    if "event_time" in event_data and isinstance(event_data["event_time"], datetime):
+        event_data["event_time"] = event_data["event_time"].isoformat()
+    else:
+        event_data["event_time"] = datetime.now(timezone.utc).isoformat()
+
+    event_data["app_context"] = get_call_stack_string()
+
+    index_map = {v: i for i, v in enumerate(LOG_FIELDS)}
+    final_log_dict = {
+        k: v
+        for k, v in sorted(event_data.items(), key=lambda pair: index_map[pair[0]])
+    }
+
+    data_dict = json.dumps(final_log_dict)
+
+    try:
+        config = Config(
+            connect_timeout=2,
+            read_timeout=10,
+            retries={"max_attempts": 2},
+        )
+        kinesis_client = boto3.client("kinesis", region_name="us-east-1", config=config)
+        response = kinesis_client.put_record(
+            StreamName=KINESIS_STREAM_NAME,
+            Data=data_dict,
+            PartitionKey=hash_id
+        )
+        logger.debug(f"Data sent to Kinesis: {data_dict}")
+    except Exception as e:
+        logger.error(f"Exception occurred: {str(e)}")
+        logger.error("Could not log data into Redshift from Kinesis")
+
+
+
+# # Redshift table DDL for web_researcher_external_api_events
+# REDSHIFT_TABLE_DDL = """
+# CREATE TABLE IF NOT EXISTS raw_import.web_researcher_external_api_events (
+#     id VARCHAR(100),
+#     vendor_name VARCHAR(100),
+#     api_name VARCHAR(100),
+#     reference_id_type VARCHAR(100),
+#     reference_id VARCHAR(100),
+#     app_name VARCHAR(100),
+#     app_context VARCHAR(5000),
+#     status VARCHAR(5000),
+#     hit_cache BOOLEAN,
+#     event_count INTEGER,
+#     event_time TIMESTAMP
+# )
+# DISTKEY (reference_id)
+# SORTKEY (event_time);
+# """
+
+
+# if __name__ == "__main__":
+#     test()

--- a/gpt_researcher/retrievers/__init__.py
+++ b/gpt_researcher/retrievers/__init__.py
@@ -8,7 +8,7 @@ from .searx.searx import SearxSearch
 from .serpapi.serpapi import SerpApiSearch
 from .serper.serper import SerperSearch
 from .tavily.tavily_search import TavilySearch
-
+from .brightdata.brightdata import BrightDataSearch
 __all__ = [
     "TavilySearch",
     "CustomRetriever",
@@ -19,5 +19,6 @@ __all__ = [
     "SearxSearch",
     "BingSearch",
     "ArxivSearch",
-    "ExaSearch"
+    "ExaSearch",
+    "BrightDataSearch",
 ]

--- a/gpt_researcher/retrievers/arxiv/arxiv.py
+++ b/gpt_researcher/retrievers/arxiv/arxiv.py
@@ -28,6 +28,7 @@ class ArxivSearch:
         )))
 
         search_result = []
+        err_msg = ""
 
         for result in arxiv_gen:
 
@@ -37,4 +38,4 @@ class ArxivSearch:
                 "body": result.summary,
             })
         
-        return search_result
+        return search_result, err_msg

--- a/gpt_researcher/retrievers/bing/bing.py
+++ b/gpt_researcher/retrievers/bing/bing.py
@@ -59,16 +59,19 @@ class BingSearch():
         }
         
         resp = requests.get(url, headers=headers, params=params)
-
+        err_msg = ""
         # Preprocess the results
-        if resp is None:
-            return
+        if resp is None:    
+            err_msg = "Bing search returned None"
+            return [], err_msg
         try:
             search_results = json.loads(resp.text)
         except Exception:
-            return
+            err_msg = "Bing search did not return a valid JSON response"
+            return [], err_msg
         if search_results is None:
-            return
+            err_msg = "Bing search returned an empty response"
+            return [], err_msg
 
         results = search_results["webPages"]["value"]
         search_results = []
@@ -85,4 +88,4 @@ class BingSearch():
             }
             search_results.append(search_result)
 
-        return search_results
+        return search_results, err_msg

--- a/gpt_researcher/retrievers/brightdata/brightdata.py
+++ b/gpt_researcher/retrievers/brightdata/brightdata.py
@@ -108,12 +108,6 @@ class BrightDataSearch:
             logger.info(f"BrightData search returned {len(results)} results")
 
 
-            #CHANGE THIS TO RETURN A LIST OF DICTIONARIES WITH RESULTS
-            # return {
-            #     'results': results,
-            #     'query': self.query,
-            #     'search_engine': 'brightdata'
-            # }
             return results, err_msg
             
         except Exception as e:

--- a/gpt_researcher/retrievers/brightdata/brightdata.py
+++ b/gpt_researcher/retrievers/brightdata/brightdata.py
@@ -1,0 +1,124 @@
+
+
+## Copy paste the brightdata client from https://github.com/homelight/hl-docker-airflow/blob/main/dags/dw_dags/libs/web_researcher/brightdata_client.py
+
+import requests
+import os
+import json
+import urllib.parse as urlparse
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import List, Dict, Any, Optional
+
+
+# Initialize logging
+logger = logging.getLogger(__name__)
+
+class BrightDataSearch:
+    """
+    Client for BrightData web search API
+    """
+    def __init__(self, query: str, zone: str = "hl_eng_serp_api1" ):
+        """
+        Initialize the BrightData client
+        Args:
+            api_token (str): BrightData API token
+        """
+        self.api_token = self.get_api_key()
+        self.base_url = "https://api.brightdata.com/request"
+        self.zone=zone
+        self.query = query
+
+    def get_api_key(self):
+        """
+        Gets the BrightData API key
+        """
+        try:
+            api_key = os.environ["BRIGHTDATA_API_KEY"]
+        except:
+            raise Exception("Bright data API key not found. Please set the BRIGHTDATA_API_KEY environment variable. ")
+        return api_key
+
+
+    def search(self,max_results: int = 15, include_domains: Optional[List[str]] = None):
+        """
+        Search the web using BrightData
+        
+        Args:
+            query (str): The search query
+            max_results (int): Maximum number of results to return
+            include_domains (list): List of domains to include in search results
+            
+        Returns:
+            dict: Search results in a format similar to Tavily
+        """
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_token}"
+        }
+        
+        # Build the complete query including domain filters if specified
+        search_query = self.query
+        if include_domains and len(include_domains) > 0:
+            domain_filter = " " + " OR ".join([f"site:{domain}" for domain in include_domains])
+            search_query += domain_filter
+            
+        # Encode the complete query for URL
+        encoded_query = urlparse.quote(search_query)
+        
+        payload = {
+            "zone": self.zone,
+            "url": f"https://www.google.com/search?q={encoded_query}&brd_json=1&num={max_results}",
+            "format": "json"
+        }
+        
+        try:
+            # logger.info(f"Sending BrightData search request for query: {self.query}")
+            response = requests.post(self.base_url, headers=headers, json=payload)
+            if 'error' in response.text.lower():
+                # logger.error(f"BrightData search error: {response.text}")
+                raise Exception(f"BrightData search error: {response.text}")
+            response.raise_for_status()
+            
+            # Parse the response
+            body = response.json().get('body', '{}')
+            if isinstance(body, str):
+                data = json.loads(body)
+            else:
+                data = body
+                
+            # Convert to Tavily-like format
+            results = []
+            err_msg = ""
+            if 'organic' in data:
+                for item in data['organic'][:max_results]:
+                    results.append({
+                        'href': item.get('link', ''),
+                        'title': item.get('title', ''),
+                        'body': item.get('description', ''),
+                        'score': 1.0 - (item.get('rank', 0) / max(max_results, 1)),  # Normalize score
+                        'source': 'brightdata'
+                    })
+            
+            if len(results) == 0:
+                err_msg = f"BrightData search returned No results for query: {self.query}"
+                logger.error(err_msg)
+                raise Exception(err_msg)
+            
+            logger.info(f"BrightData search returned {len(results)} results")
+
+
+            #CHANGE THIS TO RETURN A LIST OF DICTIONARIES WITH RESULTS
+            # return {
+            #     'results': results,
+            #     'query': self.query,
+            #     'search_engine': 'brightdata'
+            # }
+            return results, err_msg
+            
+        except Exception as e:
+            # logger.error(f"Error in BrightData search: {str(e)}")
+            print(f"Error in BrightData search: {str(e)}")
+            logger.info(f"BrightData search had the following error: {str(e)}")
+
+            return [], str(e)

--- a/gpt_researcher/retrievers/custom/custom.py
+++ b/gpt_researcher/retrievers/custom/custom.py
@@ -43,10 +43,12 @@ class CustomRetriever:
               }
             ]
         """
+        err_msg = ""
         try:
             response = requests.get(self.endpoint, params={**self.params, 'query': self.query})
             response.raise_for_status()
-            return response.json()
+            return response.json(), err_msg
         except requests.RequestException as e:
-            print(f"Failed to retrieve search results: {e}")
-            return None
+            err_msg = f"Failed to retrieve search results: {e}"
+            print(err_msg)
+            return [], err_msg

--- a/gpt_researcher/retrievers/duckduckgo/duckduckgo.py
+++ b/gpt_researcher/retrievers/duckduckgo/duckduckgo.py
@@ -17,5 +17,6 @@ class Duckduckgo:
         :param max_results:
         :return:
         """
+        err_msg = ""
         ddgs_gen = self.ddg.text(self.query, region='wt-wt', max_results=max_results)
-        return ddgs_gen
+        return ddgs_gen, err_msg

--- a/gpt_researcher/retrievers/exa/exa.py
+++ b/gpt_researcher/retrievers/exa/exa.py
@@ -48,6 +48,7 @@ class ExaSearch:
         Returns:
             A list of search results.
         """
+        err_msg = ""
         results = self.client.search(
             self.query,
             type=search_type,
@@ -55,11 +56,10 @@ class ExaSearch:
             num_results=max_results,
             **filters
         )
-
         search_response = [
             {"href": result.url, "body": result.text} for result in results.results
         ]
-        return search_response
+        return search_response, err_msg
 
     def find_similar(self, url, exclude_source_domain=False, **filters):
         """

--- a/gpt_researcher/retrievers/google/google.py
+++ b/gpt_researcher/retrievers/google/google.py
@@ -60,15 +60,19 @@ class GoogleSearch:
         print("Searching with query {0}...".format(self.query))
         url = f"https://www.googleapis.com/customsearch/v1?key={self.api_key}&cx={self.cx_key}&q={self.query}&start=1"
         resp = requests.get(url)
-
+        err_msg = ""
+        
         if resp is None:
-            return
+            err_msg = "Google search returned None"
+            return [], err_msg
         try:
             search_results = json.loads(resp.text)
         except Exception:
-            return
+            err_msg = "Google search did not return a valid JSON response"
+            return [], err_msg
         if search_results is None:
-            return
+            err_msg = "Google search returned an empty JSON response"
+            return [], err_msg
 
         results = search_results.get("items", [])
         search_results = []
@@ -85,4 +89,4 @@ class GoogleSearch:
             }
             search_results.append(search_result)
 
-        return search_results
+        return search_results, err_msg

--- a/gpt_researcher/retrievers/searx/searx.py
+++ b/gpt_researcher/retrievers/searx/searx.py
@@ -42,6 +42,7 @@ class SearxSearch():
         """
         searx = SearxSearchWrapper(searx_host=os.environ["SEARX_URL"])
         results = searx.results(self.query, max_results)
+        err_msg = ""
         # Normalizing results to match the format of the other search APIs
         search_response = [{"href": obj["link"], "body": obj["snippet"]} for obj in results]
-        return search_response
+        return search_response, err_msg 

--- a/gpt_researcher/retrievers/serpapi/serpapi.py
+++ b/gpt_researcher/retrievers/serpapi/serpapi.py
@@ -50,6 +50,7 @@ class SerpApiSearch():
         }
         encoded_url = url + "?" + urllib.parse.urlencode(params)
         search_response = []
+        err_msg = ""
         try:
             response = requests.get(encoded_url, timeout=10)
             if response.status_code == 200:
@@ -71,7 +72,8 @@ class SerpApiSearch():
                         results_processed += 1    
         except Exception as e: # Fallback in case overload on Tavily Search API
             print(f"Error: {e}")
+            err_msg = f"Error: {e}"
             ddg = DDGS()
             search_response = ddg.text(self.query, region='wt-wt', max_results=max_results)
 
-        return search_response
+        return search_response, err_msg

--- a/gpt_researcher/retrievers/serper/serper.py
+++ b/gpt_researcher/retrievers/serper/serper.py
@@ -44,6 +44,7 @@ class SerperSearch():
 
         # Search the query (see https://serper.dev/playground for the format)
         url = "https://google.serper.dev/search"
+        err_msg = ""
 
         headers = {
         'X-API-KEY': self.api_key,
@@ -55,13 +56,16 @@ class SerperSearch():
 
         # Preprocess the results
         if resp is None:
-            return
+            err_msg = "Serper search returned None"
+            return [], err_msg
         try:
             search_results = json.loads(resp.text)
         except Exception:
-            return
+            err_msg = "Serper search did not return a valid JSON response"
+            return [], err_msg
         if search_results is None:
-            return
+            err_msg = "Serper search returned an empty JSON response"
+            return [], err_msg
 
         results = search_results["organic"]
         search_results = []
@@ -78,4 +82,4 @@ class SerperSearch():
             }
             search_results.append(search_result)
 
-        return search_results
+        return search_results, err_msg

--- a/gpt_researcher/retrievers/tavily/tavily_search.py
+++ b/gpt_researcher/retrievers/tavily/tavily_search.py
@@ -41,6 +41,7 @@ class TavilySearch():
         Returns:
 
         """
+        err_msg = ""
         try:
             # Search the query
             results = self.client.search(self.query, search_depth="basic", max_results=max_results, topic=self.topic)
@@ -50,11 +51,14 @@ class TavilySearch():
             # Return the results
             search_response = [{"href": obj["url"], "body": obj["content"], "title": obj["title"]} for obj in sources]
         except Exception as e: # Fallback in case overload on Tavily Search API
-            print(f"Error: {e}. Fallback to DuckDuckGo Search API...")
+            err_msg = f"Error: {e}. Fallback to DuckDuckGo Search API..."
+            print(err_msg)
             try:
                 ddg = DDGS()
                 search_response = ddg.text(self.query, region='wt-wt', max_results=max_results)
             except Exception as e:
-                print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
+                err_msg = f"Error: {e}. Failed fetching sources. Resulting in empty response."
+                print(err_msg)
                 search_response = []
-        return search_response
+                
+        return search_response, err_msg


### PR DESCRIPTION
In this PR, I added:

1. Under gpt-researcher/retievers/:
      1. brightdata retriever by adapting the brightdata client in web_researcher
      2. modified the output of the other retrievers so that the output is consistent
2. Under gpt-researcher/master/:
     1. Added looging.py, which a direct adaptation of api_log.py in web_researcher
3. changed gpt-researcher/config/config.py to make brightdata the default retriever.


The code passed gpt-researcher-test.py, the logs are registered correctly in the Redshift table and the docker image in the dev lambda function deploys correctly and when running test_post_sqs.py, logs show correctly in CloudWatch.