### PR TITLE
Not raising non-errors

### DIFF
--- a/gpt_researcher/retrievers/brightdata/brightdata.py
+++ b/gpt_researcher/retrievers/brightdata/brightdata.py
@@ -76,7 +76,7 @@ class BrightDataSearch:
             # logger.info(f"Sending BrightData search request for query: {self.query}")
             response = requests.post(self.base_url, headers=headers, json=payload)
             if 'error' in response.text.lower():
-                if '"status_code":200' not in response.text and "No results for query" not in response.text:
+                if response.status_code != 200 and "No results for query" not in response.text:
                     raise Exception(f"BrightData search error: {response.text}")
                 else:
                     logger.info(f"BrightData search issue, not an error: {response.text}")

--- a/gpt_researcher/retrievers/brightdata/brightdata.py
+++ b/gpt_researcher/retrievers/brightdata/brightdata.py
@@ -76,8 +76,10 @@ class BrightDataSearch:
             # logger.info(f"Sending BrightData search request for query: {self.query}")
             response = requests.post(self.base_url, headers=headers, json=payload)
             if 'error' in response.text.lower():
-                # logger.error(f"BrightData search error: {response.text}")
-                raise Exception(f"BrightData search error: {response.text}")
+                if '"status_code":200' not in response.text and "No results for query" not in response.text:
+                    raise Exception(f"BrightData search error: {response.text}")
+                else:
+                    logger.info(f"BrightData search issue, not an error: {response.text}")
             response.raise_for_status()
             
             # Parse the response
@@ -112,7 +114,6 @@ class BrightDataSearch:
             
         except Exception as e:
             # logger.error(f"Error in BrightData search: {str(e)}")
-            print(f"Error in BrightData search: {str(e)}")
             logger.info(f"BrightData search had the following error: {str(e)}")
 
             return [], str(e)


### PR DESCRIPTION
- not raising errors when certain errors are flagged
- in the logging table 95% of logged errors were these two cases, not raising them will decrease the cloudwatch errors by a lot
   - if `status_code:200` we don't need to raise the error, it's just letting the user know that the AI overview is not available
   - if there is no results found for an agent/property we don't need to raise an error, that is an acceptable result
Here are what the errors look like:
```
AI Overview did not appear on original SERP
```
```
error - BrightData search returned No results for query: Edilenia Tavarez Colon in Clayton NC real estate agent
```

You can look at them with this query:
```
select *
from web_researcher_external_api_events
where status != 'success'
  and app_name = 'gpt-researcher';
```