### PR TITLE
remove raising error

### DIFF
--- a/gpt_researcher/retrievers/brightdata/brightdata.py
+++ b/gpt_researcher/retrievers/brightdata/brightdata.py
@@ -104,8 +104,7 @@ class BrightDataSearch:
             
             if len(results) == 0:
                 err_msg = f"BrightData search returned No results for query: {self.query}"
-                logger.error(err_msg)
-                raise Exception(err_msg)
+                logger.info(err_msg)
             
             logger.info(f"BrightData search returned {len(results)} results")
 


### PR DESCRIPTION
# Description
- removed raising exception when there is no search result found
- this is normal behavior when a real estate agent is not found in the search
[sc-162218](https://app.shortcut.com/homelight/story/162218/gpt-researcher-fix-brightdata-search-logging-issues)