### PR TITLE
Fixing token limit error

### DIFF
--- a/gpt_researcher/context/compression.py
+++ b/gpt_researcher/context/compression.py
@@ -1,8 +1,6 @@
 import os
 from .retriever import SearchAPIRetriever
-from langchain.retrievers import (
-    ContextualCompressionRetriever,
-)
+from langchain.retrievers import ContextualCompressionRetriever
 from langchain.retrievers.document_compressors import (
     DocumentCompressorPipeline,
     EmbeddingsFilter,
@@ -10,40 +8,90 @@ from langchain.retrievers.document_compressors import (
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from gpt_researcher.utils.costs import estimate_embedding_cost
 from gpt_researcher.memory.embeddings import OPENAI_EMBEDDING_MODEL
+from tiktoken import encoding_for_model
+
+def filter_docs_to_token_limit(docs, max_tokens=250000, model=OPENAI_EMBEDDING_MODEL):
+    """Reduce document list to stay under token limits. Works with dicts or Document objects."""
+    enc = encoding_for_model(model)
+    filtered = []
+    total_tokens = 0
+    for doc in docs:
+        if isinstance(doc, dict):
+            text = doc.get("page_content", "")
+        else:
+            text = getattr(doc, "page_content", "")
+        tokens = len(enc.encode(text))
+        if total_tokens + tokens > max_tokens:
+            break
+        filtered.append(doc)
+        total_tokens += tokens
+    print(f"[DEBUG] Filtered docs count: {len(filtered)}, total tokens: {total_tokens}")
+    return filtered
 
 
 class ContextCompressor:
     def __init__(self, documents, embeddings, max_results=5, **kwargs):
         self.max_results = max_results
-        self.documents = documents
         self.kwargs = kwargs
         self.embeddings = embeddings
-        self.similarity_threshold = os.environ.get("SIMILARITY_THRESHOLD", 0.38)
+        self.similarity_threshold = float(os.environ.get("SIMILARITY_THRESHOLD", 0.38))
+
+        # Filter documents to stay under embedding token limit
+        self.documents = filter_docs_to_token_limit(documents)
+        if not self.documents:
+            print("[WARN] No relevant context found — skipped due to empty or over-limit input.")
 
     def __get_contextual_retriever(self):
-        splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=100)
-        relevance_filter = EmbeddingsFilter(embeddings=self.embeddings,
-                                            similarity_threshold=self.similarity_threshold)
+        splitter = RecursiveCharacterTextSplitter(chunk_size=5000, chunk_overlap=100)
+        
+        def limit_chunks(chunks, max_tokens=280000):
+            enc = encoding_for_model(OPENAI_EMBEDDING_MODEL)
+            filtered = []
+            total_tokens = 0
+            for chunk in chunks:
+                text = chunk.page_content
+                tokens = len(enc.encode(text))
+                if total_tokens + tokens > max_tokens:
+                    break
+                filtered.append(chunk)
+                total_tokens += tokens
+            print(f"[DEBUG] Filtered chunks count: {len(filtered)}, total tokens: {total_tokens}")
+            return filtered
+
+        class TokenLimitEmbeddingsFilter(EmbeddingsFilter):
+            def compress_documents(self, documents, query=None, **kwargs):
+                limited_docs = limit_chunks(documents)
+                return super().compress_documents(limited_docs, query=query, **kwargs)
+
+        relevance_filter = TokenLimitEmbeddingsFilter(
+            embeddings=self.embeddings,
+            similarity_threshold=self.similarity_threshold
+        )
+        
         pipeline_compressor = DocumentCompressorPipeline(
             transformers=[splitter, relevance_filter]
         )
-        base_retriever = SearchAPIRetriever(
-            pages=self.documents
-        )
+        
+        base_retriever = SearchAPIRetriever(pages=self.documents)
         contextual_retriever = ContextualCompressionRetriever(
             base_compressor=pipeline_compressor, base_retriever=base_retriever
         )
+        
         return contextual_retriever
 
     def __pretty_print_docs(self, docs, top_n):
-        return f"\n".join(f"Source: {d.metadata.get('source')}\n"
-                          f"Title: {d.metadata.get('title')}\n"
-                          f"Content: {d.page_content}\n"
-                          for i, d in enumerate(docs) if i < top_n)
+        return "\n".join(
+            f"Source: {d.metadata.get('source')}\n"
+            f"Title: {d.metadata.get('title')}\n"
+            f"Content: {d.page_content}\n"
+            for i, d in enumerate(docs) if i < top_n
+        )
 
     def get_context(self, query, max_results=5, cost_callback=None):
         compressed_docs = self.__get_contextual_retriever()
         if cost_callback:
-            cost_callback(estimate_embedding_cost(model=OPENAI_EMBEDDING_MODEL, docs=self.documents))
+            cost_callback(
+                estimate_embedding_cost(model=OPENAI_EMBEDDING_MODEL, docs=self.documents)
+            )
         relevant_docs = compressed_docs.invoke(query)
         return self.__pretty_print_docs(relevant_docs, max_results)


### PR DESCRIPTION
# Description
- fixing search errors by limiting tokens in each chunk to 280k, limit is 300k.
Here is an error:
```
[ERROR] BadRequestError: Error code: 400 - {'error': {'message': 'Requested 394138 tokens, max 300000 tokens per request', 'type': 'max_tokens_per_request', 'param': None, 'code': 'max_tokens_per_request'}}
Traceback (most recent call last):
  File "/var/task/lambda_function.py", line 54, in lambda_handler
    research_obj = loop.run_until_complete(async_handler(obj))
  File "/var/lang/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
  File "/var/task/lambda_function.py", line 31, in async_handler
    research_obj = await clients.gpt_research(obj, VERBOSE)
  File "/var/task/clients.py", line 138, in gpt_research
    combined_results = await asyncio.gather(
  File "/var/task/clients.py", line 299, in run_people_research
    research_result = await researcher.conduct_research()
  File "/var/task/gpt-researcher/gpt_researcher/master/agent.py", line 107, in conduct_research
    self.context = await self.__get_context_by_search_queries(self.web_search_queries)
  File "/var/task/gpt-researcher/gpt_researcher/master/agent.py", line 243, in __get_context_by_search_queries
    context = await asyncio.gather(*[self.__process_sub_query(sub_query, scraped_data) for sub_query in sub_queries])
  File "/var/task/gpt-researcher/gpt_researcher/master/agent.py", line 269, in __process_sub_query
    scraped_content = await self.__get_similar_content_by_query(sub_query, scraped_data)
  File "/var/task/gpt-researcher/gpt_researcher/master/agent.py", line 353, in __get_similar_content_by_query
    return context_compressor.get_context(query=query, max_results=8, cost_callback=self.add_costs)
  File "/var/task/gpt-researcher/gpt_researcher/context/compression.py", line 48, in get_context
    relevant_docs = compressed_docs.invoke(query)
  File "/var/lang/lib/python3.11/site-packages/langchain_core/retrievers.py", line 252, in invoke
    raise e
  File "/var/lang/lib/python3.11/site-packages/langchain_core/retrievers.py", line 245, in invoke
    result = self._get_relevant_documents(
  File "/var/lang/lib/python3.11/site-packages/langchain/retrievers/contextual_compression.py", line 46, in _get_relevant_documents
    compressed_docs = self.base_compressor.compress_documents(
  File "/var/lang/lib/python3.11/site-packages/langchain/retrievers/document_compressors/base.py", line 37, in compress_documents
    documents = _transformer.compress_documents(
  File "/var/lang/lib/python3.11/site-packages/langchain/retrievers/document_compressors/embeddings_filter.py", line 72, in compress_documents
    embedded_documents = _get_embeddings_from_stateful_docs(
  File "/var/lang/lib/python3.11/site-packages/langchain_community/document_transformers/embeddings_redundant_filter.py", line 71, in _get_embeddings_from_stateful_docs
    embedded_documents = embeddings.embed_documents(
  File "/var/lang/lib/python3.11/site-packages/langchain_openai/embeddings/base.py", line 592, in embed_documents
    return self._get_len_safe_embeddings(texts, engine=engine)
  File "/var/lang/lib/python3.11/site-packages/langchain_openai/embeddings/base.py", line 490, in _get_len_safe_embeddings
    response = self.client.create(
  File "/var/lang/lib/python3.11/site-packages/openai/resources/embeddings.py", line 129, in create
    return self._post(
  File "/var/lang/lib/python3.11/site-packages/openai/_base_client.py", line 1239, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  File "/var/lang/lib/python3.11/site-packages/openai/_base_client.py", line 1034, in request
    raise self._make_status_error_from_response(err.response) from None

```


Here is what the fix looks like in the logs:
```

[DEBUG] Filtered docs count: 3, total tokens: 0
[DEBUG] Filtered chunks count: 123, total tokens: 277969

```